### PR TITLE
Remove asynchrony from domain

### DIFF
--- a/apps/android/taskodoro/src/main/kotlin/com/taskodoro/android/app/di/TasksComposer.kt
+++ b/apps/android/taskodoro/src/main/kotlin/com/taskodoro/android/app/di/TasksComposer.kt
@@ -19,17 +19,24 @@ package com.taskodoro.android.app.di
 import com.taskodoro.android.app.tasks.TasksViewModel
 import com.taskodoro.tasks.data.TaskRepository
 import com.taskodoro.tasks.data.datasources.InMemoryTaskDataSource
+import com.taskodoro.tasks.model.Task
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 
 object TasksComposer {
+
+    private val tasks: Flow<List<Task>> by lazy {
+        flowEmitting { repository.getTasks() }
+            .flowOn(Dispatchers.IO)
+    }
 
     private val repository: TaskRepository by lazy {
         TaskRepository(localDataSource = InMemoryTaskDataSource())
     }
 
-    fun tasksViewModel(): TasksViewModel =
-        TasksViewModel(
-            getTasks = repository::getTasks,
-            dispatcher = Dispatchers.Main
-        )
+    fun tasksViewModel(): TasksViewModel = TasksViewModel(getTasks = tasks)
 }
+
+inline fun <T> flowEmitting(crossinline block: suspend () -> T): Flow<T> = flow { emit(block()) }

--- a/apps/android/taskodoro/src/main/kotlin/com/taskodoro/android/app/tasks/TasksScreen.kt
+++ b/apps/android/taskodoro/src/main/kotlin/com/taskodoro/android/app/tasks/TasksScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -37,6 +38,10 @@ fun TasksScreen(
     viewModel: TasksViewModel = TasksComposer.tasksViewModel()
 ) {
     val tasks = viewModel.tasks.collectAsState()
+
+    LaunchedEffect(tasks) {
+        viewModel.getTasks()
+    }
 
     TasksContent(tasks.value)
 }

--- a/apps/android/taskodoro/src/main/kotlin/com/taskodoro/android/app/tasks/TasksViewModel.kt
+++ b/apps/android/taskodoro/src/main/kotlin/com/taskodoro/android/app/tasks/TasksViewModel.kt
@@ -28,13 +28,13 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 
 class TasksViewModel(
-    getTasks: Flow<List<Task>>
+    private val getTasks: Flow<List<Task>>
 ) : ViewModel() {
 
     private val _tasks = MutableStateFlow(emptyList<Task>())
     val tasks = _tasks.asStateFlow()
 
-    init {
+    fun getTasks() {
         getTasks
             .onEach(::updateState)
             .catch { updateState(emptyList()) }

--- a/apps/android/taskodoro/src/main/kotlin/com/taskodoro/android/app/tasks/TasksViewModel.kt
+++ b/apps/android/taskodoro/src/main/kotlin/com/taskodoro/android/app/tasks/TasksViewModel.kt
@@ -19,27 +19,29 @@ package com.taskodoro.android.app.tasks
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.taskodoro.tasks.model.Task
-import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 
 class TasksViewModel(
-    getTasks: suspend () -> List<Task>,
-    dispatcher: CoroutineDispatcher,
+    getTasks: Flow<List<Task>>
 ) : ViewModel() {
 
     private val _tasks = MutableStateFlow(emptyList<Task>())
     val tasks = _tasks.asStateFlow()
 
     init {
-        viewModelScope.launch(dispatcher) {
-            val tasks = getTasks()
-            updateState(tasks = tasks)
-        }
+        getTasks
+            .onEach(::updateState)
+            .catch { updateState(emptyList()) }
+            .launchIn(viewModelScope)
     }
 
     private fun updateState(tasks: List<Task>) {
-        _tasks.value = tasks
+        _tasks.update { tasks }
     }
 }

--- a/apps/ios/Taskodoro/Taskodoro.xcodeproj/project.pbxproj
+++ b/apps/ios/Taskodoro/Taskodoro.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		88CC304927B3D5B300D08D2C /* TaskodoroApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88CC304827B3D5B300D08D2C /* TaskodoroApp.swift */; };
 		88CC304B27B3D5B300D08D2C /* TasksScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88CC304A27B3D5B300D08D2C /* TasksScreen.swift */; };
 		88CC304D27B3D5B600D08D2C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 88CC304C27B3D5B600D08D2C /* Assets.xcassets */; };
+		B11352E5282C57ED00EA0D9D /* CombineHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11352E4282C57ED00EA0D9D /* CombineHelpers.swift */; };
+		B11352E8282C58D400EA0D9D /* TasksUIComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11352E7282C58D400EA0D9D /* TasksUIComposer.swift */; };
+		B11352EB282C5CA900EA0D9D /* TasksContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11352EA282C5CA900EA0D9D /* TasksContent.swift */; };
 		B19DA0D628232A4E002C433A /* TasksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19DA0D528232A4E002C433A /* TasksViewModel.swift */; };
 /* End PBXBuildFile section */
 
@@ -31,6 +34,9 @@
 		88CC304827B3D5B300D08D2C /* TaskodoroApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskodoroApp.swift; sourceTree = "<group>"; };
 		88CC304A27B3D5B300D08D2C /* TasksScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksScreen.swift; sourceTree = "<group>"; };
 		88CC304C27B3D5B600D08D2C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B11352E4282C57ED00EA0D9D /* CombineHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineHelpers.swift; sourceTree = "<group>"; };
+		B11352E7282C58D400EA0D9D /* TasksUIComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksUIComposer.swift; sourceTree = "<group>"; };
+		B11352EA282C5CA900EA0D9D /* TasksContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksContent.swift; sourceTree = "<group>"; };
 		B19DA0D528232A4E002C433A /* TasksViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -81,17 +87,36 @@
 		88CC304727B3D5B300D08D2C /* Taskodoro */ = {
 			isa = PBXGroup;
 			children = (
+				B11352E6282C58B700EA0D9D /* DI */,
 				B19DA0D4282329CC002C433A /* Tasks */,
 				88CC304827B3D5B300D08D2C /* TaskodoroApp.swift */,
+				B11352E4282C57ED00EA0D9D /* CombineHelpers.swift */,
 				88CC304C27B3D5B600D08D2C /* Assets.xcassets */,
 			);
 			path = Taskodoro;
 			sourceTree = "<group>";
 		};
-		B19DA0D4282329CC002C433A /* Tasks */ = {
+		B11352E6282C58B700EA0D9D /* DI */ = {
+			isa = PBXGroup;
+			children = (
+				B11352E7282C58D400EA0D9D /* TasksUIComposer.swift */,
+			);
+			path = DI;
+			sourceTree = "<group>";
+		};
+		B11352E9282C5C9C00EA0D9D /* UI */ = {
 			isa = PBXGroup;
 			children = (
 				88CC304A27B3D5B300D08D2C /* TasksScreen.swift */,
+				B11352EA282C5CA900EA0D9D /* TasksContent.swift */,
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
+		B19DA0D4282329CC002C433A /* Tasks */ = {
+			isa = PBXGroup;
+			children = (
+				B11352E9282C5C9C00EA0D9D /* UI */,
 				B19DA0D528232A4E002C433A /* TasksViewModel.swift */,
 			);
 			path = Tasks;
@@ -226,9 +251,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B11352E8282C58D400EA0D9D /* TasksUIComposer.swift in Sources */,
 				88CC304B27B3D5B300D08D2C /* TasksScreen.swift in Sources */,
+				B11352EB282C5CA900EA0D9D /* TasksContent.swift in Sources */,
 				B19DA0D628232A4E002C433A /* TasksViewModel.swift in Sources */,
 				88CC304927B3D5B300D08D2C /* TaskodoroApp.swift in Sources */,
+				B11352E5282C57ED00EA0D9D /* CombineHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/Taskodoro/Taskodoro/CombineHelpers.swift
+++ b/apps/ios/Taskodoro/Taskodoro/CombineHelpers.swift
@@ -13,17 +13,16 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
+        
 
-import SwiftUI
+import Foundation
+import Combine
 
-@main
-struct TaskodoroApp: App {
-    
-    private let tasksViewModel = TasksUIComposer.makeTasksViewModel()
-    
-    var body: some Scene {
-        WindowGroup {
-            TasksScreen(viewModel: tasksViewModel)
+func deferredFuture<T>(_ block: @escaping () -> T) -> AnyPublisher<T, Error> {
+    return Deferred {
+        Future { completion in
+            completion(Result { block() } )
         }
     }
+    .eraseToAnyPublisher()
 }

--- a/apps/ios/Taskodoro/Taskodoro/DI/TasksUIComposer.swift
+++ b/apps/ios/Taskodoro/Taskodoro/DI/TasksUIComposer.swift
@@ -24,6 +24,8 @@ final class TasksUIComposer {
     static func makeTasksViewModel() -> TasksViewModel {
         let taskRepository = TaskRepository(localDataSource: InMemoryTaskDataSource())
         let tasksLoader = deferredFuture(taskRepository.getTasks)
+            .subscribe(on: DispatchQueue.global())
+            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
         
         return TasksViewModel(tasksLoader)

--- a/apps/ios/Taskodoro/Taskodoro/DI/TasksUIComposer.swift
+++ b/apps/ios/Taskodoro/Taskodoro/DI/TasksUIComposer.swift
@@ -14,16 +14,18 @@
 //  limitations under the License.
 //
 
-import SwiftUI
 
-@main
-struct TaskodoroApp: App {
+import Foundation
+import Tasks
+
+final class TasksUIComposer {
+    private init() {}
     
-    private let tasksViewModel = TasksUIComposer.makeTasksViewModel()
-    
-    var body: some Scene {
-        WindowGroup {
-            TasksScreen(viewModel: tasksViewModel)
-        }
+    static func makeTasksViewModel() -> TasksViewModel {
+        let taskRepository = TaskRepository(localDataSource: InMemoryTaskDataSource())
+        let tasksLoader = deferredFuture(taskRepository.getTasks)
+            .eraseToAnyPublisher()
+        
+        return TasksViewModel(tasksLoader)
     }
 }

--- a/apps/ios/Taskodoro/Taskodoro/Tasks/UI/TasksContent.swift
+++ b/apps/ios/Taskodoro/Taskodoro/Tasks/UI/TasksContent.swift
@@ -14,16 +14,32 @@
 //  limitations under the License.
 //
 
-import SwiftUI
 
-@main
-struct TaskodoroApp: App {
+import SwiftUI
+import Tasks
+
+struct TasksContent: View {
+    let tasks: [Task]
     
-    private let tasksViewModel = TasksUIComposer.makeTasksViewModel()
-    
-    var body: some Scene {
-        WindowGroup {
-            TasksScreen(viewModel: tasksViewModel)
+    var body: some View {
+        List(tasks) { task in
+            Text(task.title)
+                .padding()
         }
+        .listStyle(.plain)
+    }
+}
+
+extension Task : Identifiable {}
+
+struct TasksContent_Previews: PreviewProvider {
+    static var previews: some View {
+        let tasks = (0...19)
+            .map { id in
+                Task(id: id, title: "Task \(id) title")
+            }
+        TasksContent(tasks: tasks)
+        TasksContent(tasks: tasks)
+            .preferredColorScheme(.dark)
     }
 }

--- a/apps/ios/Taskodoro/Taskodoro/Tasks/UI/TasksScreen.swift
+++ b/apps/ios/Taskodoro/Taskodoro/Tasks/UI/TasksScreen.swift
@@ -25,22 +25,8 @@ struct TasksScreen: View {
         .onAppear {
             viewModel.getTasks()
         }
-    }
-}
-
-struct TasksContent: View {
-    let tasks: [Task]
-    
-    var body: some View {
-        List(tasks) { task in
-            Text(task.title)
-                .padding()
+        .onDisappear {
+            viewModel.onClear()
         }
-        .listStyle(.plain)
     }
 }
-
-extension Task : Identifiable {}
-
-
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,3 +37,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+kotlin.native.binary.memoryModel=experimental

--- a/gradle/catalogs/libs.versions.toml
+++ b/gradle/catalogs/libs.versions.toml
@@ -18,8 +18,6 @@
 kotlin = "1.6.21"
 androidBuildTools = "7.1.3"
 
-coroutines-mt = "1.6.0-native-mt"
-
 core-ktx = "1.7.0"
 compose = "1.2.0-beta01"
 activity-compose = "1.4.0"
@@ -36,8 +34,6 @@ kotlinGradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.r
 androidBuildTools = { module = "com.android.tools.build:gradle", version.ref = "androidBuildTools" }
 
 # dependencies
-kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines-mt" }
-
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
@@ -49,7 +45,6 @@ androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-kt
 # test
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-mt" }
 
 # androidTest
 androidx-test-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-junit" }

--- a/tasks/build.gradle.kts
+++ b/tasks/build.gradle.kts
@@ -35,11 +35,7 @@ kotlin {
     sourceSets {
 
         /* Main source sets */
-        val commonMain by getting {
-            dependencies {
-                implementation(libs.kotlinx.coroutines)
-            }
-        }
+        val commonMain by getting
         val jvmMain by getting
         val nativeMain by creating
         val iosMain by creating
@@ -59,7 +55,6 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(libs.kotlin.test)
-                implementation(libs.kotlinx.coroutines.test)
             }
         }
         val jvmTest by getting

--- a/tasks/src/commonMain/kotlin/com/taskodoro/tasks/data/TaskLocalDataSource.kt
+++ b/tasks/src/commonMain/kotlin/com/taskodoro/tasks/data/TaskLocalDataSource.kt
@@ -19,5 +19,5 @@ package com.taskodoro.tasks.data
 import com.taskodoro.tasks.model.Task
 
 interface TaskLocalDataSource {
-    suspend fun getAllTasks(): List<Task>
+    fun getAllTasks(): List<Task>
 }

--- a/tasks/src/commonMain/kotlin/com/taskodoro/tasks/data/TaskRepository.kt
+++ b/tasks/src/commonMain/kotlin/com/taskodoro/tasks/data/TaskRepository.kt
@@ -22,6 +22,6 @@ class TaskRepository(
     private val localDataSource: TaskLocalDataSource,
 ) {
 
-    suspend fun getTasks(): List<Task> = localDataSource.getAllTasks()
+    fun getTasks(): List<Task> = localDataSource.getAllTasks()
 }
 

--- a/tasks/src/commonMain/kotlin/com/taskodoro/tasks/data/datasources/InMemoryTaskDataSource.kt
+++ b/tasks/src/commonMain/kotlin/com/taskodoro/tasks/data/datasources/InMemoryTaskDataSource.kt
@@ -18,14 +18,11 @@ package com.taskodoro.tasks.data.datasources
 
 import com.taskodoro.tasks.data.TaskLocalDataSource
 import com.taskodoro.tasks.model.Task
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 class InMemoryTaskDataSource : TaskLocalDataSource {
 
-    override suspend fun getAllTasks(): List<Task> = withContext(Dispatchers.Default) {
+    override fun getAllTasks(): List<Task> =
         List(20) {
             Task(id = it.toLong(), title = "Task $it title")
         }
-    }
 }


### PR DESCRIPTION
Make the domain APIs synchronous and move async operations to be handled at the composition level.

To do this, we needed to enable the [new KN Memory Management](https://github.com/JetBrains/kotlin/blob/master/kotlin-native/NEW_MM.md) currently in alpha version.

Also removed `coroutines` dependency from `:tasks` module.